### PR TITLE
make ->import work after ->unimport

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires "Test::More";
-requires "Test::Time";
+requires "Test::Time" => "0.07";
 requires "Time::HiRes";
 requires "perl" => "5.008";
 requires "strict";

--- a/lib/Test/Time/HiRes.pm
+++ b/lib/Test/Time/HiRes.pm
@@ -52,6 +52,8 @@ sub import {
     my ( $class, %opts ) = @_;
 
     $in_effect = 1;
+    Test::Time->import; # make sure Test::Time is enabled, in case
+                        # there was a call to ->unimport earlier
 
     return if $imported;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -96,6 +96,9 @@ subtest unimport => sub {
     isnt Time::HiRes::time(), 123.456789, 'hires time unset';
 
     Test::Time::HiRes->import();
+
+    is time(), 123, "time set again";
+    is Time::HiRes::time(), 123.456789, 'hires time set again';
 };
 
 done_testing;


### PR DESCRIPTION
previously, there was no way to re-enable the "fake" `Test::Time` routines after they had been disabled by a call to `->unimport`

this needs a `Test::Time` that has https://github.com/cho45/Test-Time/pull/12 applied, hence the bump in version in cpanfile